### PR TITLE
Binding average rate to binding frequency filter changes

### DIFF
--- a/swga/commands/filter.py
+++ b/swga/commands/filter.py
@@ -46,8 +46,6 @@ def main(argv, cfg_file):
     if not cmd.skip_filtering:
         primers = filter_primers(
             primers,
-#            cmd.fg_min_avg_rate,
-#            cmd.bg_max_avg_rate,
             cmd.min_fg_bind,
             cmd.max_bg_bind,
             cmd.fg_length,
@@ -75,8 +73,6 @@ def activate_primers(primers):
 
 def filter_primers(
         primers,
-#        fg_min_avg_rate,
-#        bg_max_avg_rate,
         min_fg_bind,
         max_bg_bind,
         fg_length,
@@ -89,8 +85,6 @@ def filter_primers(
     those sequences that pass various criteria.
     """
     primers = Primer.select().where(Primer.seq << primers)
-#    fg_min_freq = float(fg_min_avg_rate) * fg_length
-#    bg_max_freq = float(bg_max_avg_rate) * bg_length
     fg_min_freq = min_fg_bind
     bg_max_freq = max_bg_bind
 

--- a/swga/commands/filter.py
+++ b/swga/commands/filter.py
@@ -56,10 +56,11 @@ def main(argv, cfg_file):
     
     update_locations(primers, cmd.fg_genome_fp)
     n_active = activate_primers(primers)
-    if n_active < cmd.max_primers:
+    if int(n_active) < int(cmd.max_primers):
     	swga.warn(
-    		"Fewer than {} were selected. You may want to try less "
-    		"restrictive filtering parameters.".format(cmd.max_primers))
+    		"Fewer than {} primers were selected. Only {} passed all "
+		"the filters You may want to try less "
+    		"restrictive filtering parameters.".format(cmd.max_primers, n_active))
 
 
 def deactivate_all_primers():

--- a/swga/commands/init.py
+++ b/swga/commands/init.py
@@ -73,10 +73,10 @@ def main(fg_genome_fp, bg_genome_fp):
         click.confirm("Existing file `%s` will be overwritten. Continue?" 
                       % default_parameters_name, abort=True)
 
-    min_fg_bind = 100
-    min_fg_rate = min_fg_bind/float(fg_length)
-    max_bg_bind = 10000
-    max_bg_rate = max_bg_bind/float(bg_length)
+    min_fg_rate = 0.00001
+    min_fg_bind = int(min_fg_rate*float(fg_length))
+    max_bg_rate = 0.0000067
+    max_bg_bind = int(max_bg_rate*float(bg_length))
     with open(os.path.join(cwd, default_parameters_name), "wb") as cfg_file:
         cfg_file.write(default_parameters.format(**locals()))
     

--- a/swga/commands/init.py
+++ b/swga/commands/init.py
@@ -73,6 +73,9 @@ def main(fg_genome_fp, bg_genome_fp):
         click.confirm("Existing file `%s` will be overwritten. Continue?" 
                       % default_parameters_name, abort=True)
 
+    # Calculate default binding frequencies for foreground and background
+    # Fg is based on a binding rate of 1/100000 bp/binding site
+    # Fg is based on a binding rate of 1/150000 bp/binding site
     min_fg_rate = 0.00001
     min_fg_bind = int(min_fg_rate*float(fg_length))
     max_bg_rate = 0.0000067

--- a/swga/data/options.yaml
+++ b/swga/data/options.yaml
@@ -111,14 +111,22 @@ filter:
     default: *fglen
     desc: length of the foreground genome (autofilled by swga init)
     type: int
-  fg_min_avg_rate:
-    default: *fgrate
-    desc: minimum average binding frequency over the foreground genome
-    type: float
-  bg_max_avg_rate:
-    default: *bgrate
-    desc: maximum average binding frequency over the background genome
-    type: float
+#  fg_min_avg_rate:
+#    default: *fgrate
+#    desc: minimum average binding frequency over the foreground genome
+#    type: float
+#  bg_max_avg_rate:
+#    default: *bgrate
+#    desc: maximum average binding frequency over the background genome
+#    type: float
+  min_fg_bind:
+    default: *fgbind
+    desc: minimum primer binding sites (autofilled)
+    type: int
+  max_bg_bind:
+    default: *bgbind
+    desc: maximum primer binding sites (autofilled)
+    type: int
   min_tm:
     default: 0
     desc: minimum primer melting temperature (C)

--- a/swga/data/options.yaml
+++ b/swga/data/options.yaml
@@ -111,14 +111,6 @@ filter:
     default: *fglen
     desc: length of the foreground genome (autofilled by swga init)
     type: int
-#  fg_min_avg_rate:
-#    default: *fgrate
-#    desc: minimum average binding frequency over the foreground genome
-#    type: float
-#  bg_max_avg_rate:
-#    default: *bgrate
-#    desc: maximum average binding frequency over the background genome
-#    type: float
   min_fg_bind:
     default: *fgbind
     desc: minimum primer binding sites (autofilled)

--- a/swga/data/options.yaml
+++ b/swga/data/options.yaml
@@ -45,11 +45,11 @@ count:
     type: int
   min_fg_bind:
     default: *fgbind
-    desc: minimum primer binding sites (autofilled)
+    desc: minimum primer binding sites (default autofilled based on genome length)
     type: int
   max_bg_bind:
     default: *bgbind
-    desc: maximum primer binding sites (autofilled)
+    desc: maximum primer binding sites (default autofilled based on genome length)
     type: int
   exclude_fp:
     default: null
@@ -113,11 +113,11 @@ filter:
     type: int
   min_fg_bind:
     default: *fgbind
-    desc: minimum primer binding sites (autofilled)
+    desc: minimum primer binding sites (default autofilled based on genome length)
     type: int
   max_bg_bind:
     default: *bgbind
-    desc: maximum primer binding sites (autofilled)
+    desc: maximum primer binding sites (default autofilled based on genome length)
     type: int
   min_tm:
     default: 0


### PR DESCRIPTION
Changed the `swga filter` parameters to use binding frequency instead of binding rate so the relationship with the parameter in `swga count` is more apparent.
Also added a message to indicate how many primers passed both foreground and background binding frequency filters in `swga filter`.