### PR TITLE
remove omp private directive

### DIFF
--- a/ext/dsk/minia/SortingCount.cpp
+++ b/ext/dsk/minia/SortingCount.cpp
@@ -544,7 +544,7 @@ void sorting_count(Bank *Sequences, char *prefix, int max_memory, int max_disk_s
         // TODO to guillaume: remove that todo above, because it is done, right?
 #if OMP 
         //omp_set_numthreads(2);  //num_threads(2) //if(!output_histo) num_threads(nb_threads)
-#pragma omp parallel for if (! separate_count) private (p)  num_threads(nb_threads)
+#pragma omp parallel for if (! separate_count) num_threads(nb_threads)
 #endif        
         // load, sort each partition to output solid kmers
         for (int p=0;p<nb_partitions;p++)


### PR DESCRIPTION
This pull request is based on resolving the following compiler error in the [bioconda recipe](https://github.com/bioconda/bioconda-recipes/blob/b3f8ebe38915ae82df58cc080022d367abb43420/recipes/swga/meta.yaml) for the 0.4.4 release:

```
    /usr/bin/g++ -o minia/SortingCount.o -c minia/SortingCount.cpp -O4 -fopenmp -DOMP=1
    minia/SortingCount.cpp: In function ‘void sorting_count(Bank*, char*, int, int, bool, int, bool)’:
    minia/SortingCount.cpp:547:57: error: ‘p’ has not been declared
     #pragma omp parallel for if (! separate_count) private (p)  num_threads(nb_threads)
                                                             ^
    make: *** [makefile:71: minia/SortingCount.o] Error 1
```

I think the private directive is unnecessary because p is defined inside the pragma.